### PR TITLE
Use apply instead of commit

### DIFF
--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentSettings.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentSettings.java
@@ -105,7 +105,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
             SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
             SharedPreferences.Editor editor1 = settings.edit();
             editor1.putBoolean("prefEGM96AltitudeCorrection", false);
-            editor1.commit();
+            editor1.apply();
             SwitchPreferenceCompat EGM96 = (SwitchPreferenceCompat) super.findPreference("prefEGM96AltitudeCorrection");
             EGM96.setChecked(false);
         }
@@ -125,7 +125,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
                     altcor = prefs.getString("prefUM", "0").equals("0") ? altcorm : altcorm * M_TO_FT;
                     SharedPreferences.Editor editor = prefs.edit();
                     editor.putString("prefAltitudeCorrectionRaw", String.valueOf(altcor));
-                    editor.commit();
+                    editor.apply();
                     EditTextPreference pAltitudeCorrection = (EditTextPreference) findPreference("prefAltitudeCorrectionRaw");
                     pAltitudeCorrection.setText(prefs.getString("prefAltitudeCorrectionRaw", "0"));
                 }
@@ -145,7 +145,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
                     altcorm = prefs.getString("prefUM", "0").equals("0") ? altcor : altcor / M_TO_FT;
                     SharedPreferences.Editor editor = prefs.edit();
                     editor.putString("prefAltitudeCorrection", String.valueOf(altcorm));
-                    editor.commit();
+                    editor.apply();
                 }
 
                 if (key.equals("prefEGM96AltitudeCorrection")) {
@@ -171,7 +171,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
                     SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
                     SharedPreferences.Editor editor1 = settings.edit();
                     editor1.putString(key, sharedPreferences.getString(key, "2"));
-                    editor1.commit();
+                    editor1.apply();
 
                     AppCompatDelegate.setDefaultNightMode(Integer.valueOf(PreferenceManager.getDefaultSharedPreferences(getContext()).getString("prefColorTheme", "2")));
                     getActivity().getWindow().setWindowAnimations(R.style.MyCrossfadeAnimation_Window);
@@ -279,7 +279,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
                                     SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
                                     SharedPreferences.Editor editor1 = settings.edit();
                                     editor1.putString("prefTracksViewer", aild.get(position).PackageName);
-                                    editor1.commit();
+                                    editor1.apply();
                                     SetupPreferences();
                                     dialog.dismiss();
                                 }
@@ -351,7 +351,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
         SharedPreferences.Editor editor1 = settings.edit();
         editor1.putBoolean("prefEGM96AltitudeCorrection", false);
-        editor1.commit();
+        editor1.apply();
         SwitchPreferenceCompat EGM96 = (SwitchPreferenceCompat) super.findPreference("prefEGM96AltitudeCorrection");
         EGM96.setChecked(false);
     }
@@ -360,7 +360,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
         SharedPreferences.Editor editor1 = settings.edit();
         editor1.putBoolean("prefEGM96AltitudeCorrection", true);
-        editor1.commit();
+        editor1.apply();
         SwitchPreferenceCompat EGM96 = (SwitchPreferenceCompat) super.findPreference("prefEGM96AltitudeCorrection");
         EGM96.setChecked(true);
     }
@@ -596,7 +596,7 @@ public class FragmentSettings extends PreferenceFragmentCompat {
                                     SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getContext());
                                     SharedPreferences.Editor editor1 = settings.edit();
                                     editor1.putString("prefKMLAltitudeMode", "0");
-                                    editor1.commit();
+                                    editor1.apply();
                                     ListPreference pKMLAltitudeMode = (ListPreference) findPreference("prefKMLAltitudeMode");
                                     pKMLAltitudeMode.setValue("0");
                                     pKMLAltitudeMode.setSummary(R.string.pref_KML_altitude_mode_absolute);

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/GPSApplication.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/GPSApplication.java
@@ -677,7 +677,7 @@ public class GPSApplication extends Application implements LocationListener {
         SharedPreferences preferences_nobackup = getSharedPreferences("prefs_nobackup",Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences_nobackup.edit();
         editor.putBoolean(flag, true);
-        editor.commit();
+        editor.apply();
     }
 
 
@@ -685,7 +685,7 @@ public class GPSApplication extends Application implements LocationListener {
         SharedPreferences preferences_nobackup = getSharedPreferences("prefs_nobackup", Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = preferences_nobackup.edit();
         editor.remove(flag);
-        editor.commit();
+        editor.apply();
     }
 
 
@@ -732,7 +732,7 @@ public class GPSApplication extends Application implements LocationListener {
         // TODO: Uncomment it to run the Week Rollover Tests (For Test Purpose)
         // SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit();
         // editor.putBoolean("prefGPSWeekRolloverCorrected", false);
-        // editor.commit();
+        // editor.apply();
         // -----------------------
 
         // -----------------------
@@ -1379,7 +1379,7 @@ public class GPSApplication extends Application implements LocationListener {
             SharedPreferences.Editor editor = preferences.edit();
             editor.putString("prefUM", (imperialUM ? "8" : "0"));
             editor.remove("prefShowImperialUnits");
-            editor.commit();
+            editor.apply();
         }
 
         // ---------Remove the prefIsStoragePermissionChecked in preferences if present
@@ -1387,7 +1387,7 @@ public class GPSApplication extends Application implements LocationListener {
         if (preferences.contains("prefIsStoragePermissionChecked")) {
             SharedPreferences.Editor editor = preferences.edit();
             editor.remove("prefIsStoragePermissionChecked");
-            editor.commit();
+            editor.apply();
         }
 
         // -----------------------------------------------------------------------
@@ -1420,7 +1420,7 @@ public class GPSApplication extends Application implements LocationListener {
         if (!prefExportKML && !prefExportGPX && !prefExportTXT) {
             SharedPreferences.Editor editor = preferences.edit();
             editor.putBoolean("prefExportGPX", true);
-            editor.commit();
+            editor.apply();
             prefExportGPX = true;
         }
 
@@ -1478,7 +1478,7 @@ public class GPSApplication extends Application implements LocationListener {
                 prefGPSWeekRolloverCorrected = true;
                 SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).edit();
                 editor.putBoolean("prefGPSWeekRolloverCorrected", true);
-                editor.commit();
+                editor.apply();
             }
             // ----------------------------------------------------------------------------------------
 

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/SettingsActivity.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/SettingsActivity.java
@@ -51,7 +51,7 @@ public class SettingsActivity extends AppCompatActivity {
             FragmentManager fm = getSupportFragmentManager();
             FragmentTransaction ft = fm.beginTransaction();
             ft.replace(R.id.id_preferences, wvf);
-            ft.apply();
+            ft.commit();
         }
     }
 

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/SettingsActivity.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/SettingsActivity.java
@@ -51,7 +51,7 @@ public class SettingsActivity extends AppCompatActivity {
             FragmentManager fm = getSupportFragmentManager();
             FragmentTransaction ft = fm.beginTransaction();
             ft.replace(R.id.id_preferences, wvf);
-            ft.commit();
+            ft.apply();
         }
     }
 


### PR DESCRIPTION
Consider using apply() instead of commit on shared preferences.
Whereas commit blocks and writes its data to persistent storage
immediately, apply will handle it in the background.

(As suggested by lint)