### PR TITLE
#225 - update navigation bar and icons color based on preference theme

### DIFF
--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentAboutDialog.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentAboutDialog.java
@@ -38,6 +38,8 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import eu.basicairdata.graziano.gpslogger.utils.AppUtils;
+
 /**
  * The About Dialog Fragment
  */
@@ -116,7 +118,9 @@ public class FragmentAboutDialog extends DialogFragment {
                 public void onClick(DialogInterface dialog, int id) {}
             });
 
-        return createAboutAlert.create();
+        AlertDialog alertDialog = createAboutAlert.create();
+        AppUtils.updateNavigationBarColor(alertDialog.getWindow(), getActivity().getApplicationContext());
+        return alertDialog;
     }
 
     @Override

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentSettings.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/FragmentSettings.java
@@ -69,6 +69,8 @@ import java.util.ArrayList;
 
 import static eu.basicairdata.graziano.gpslogger.GPSApplication.FILETYPE_GPX;
 
+import eu.basicairdata.graziano.gpslogger.utils.AppUtils;
+
 /**
  * The Fragment that manages the Settings on the SettingsActivity
  */
@@ -89,7 +91,9 @@ public class FragmentSettings extends PreferenceFragmentCompat {
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        if (getActivity() != null) {
+            AppUtils.updateNavigationBarColor(getActivity().getWindow(),getActivity().getApplicationContext());
+        }
         addPreferencesFromResource(R.xml.app_preferences);
 
         // TODO: check it!

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/GPSActivity.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/GPSActivity.java
@@ -67,6 +67,8 @@ import java.util.Map;
 
 import static eu.basicairdata.graziano.gpslogger.GPSApplication.TOAST_VERTICAL_OFFSET;
 
+import eu.basicairdata.graziano.gpslogger.utils.AppUtils;
+
 /**
  * The main Activity.
  * Here you can view the status of GPS, of the current Track and the list
@@ -99,6 +101,7 @@ public class GPSActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        AppUtils.updateNavigationBarColor(getWindow(),getApplicationContext());
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
         Log.w("myApp", "[#] " + this + " - onCreate()");
         setTheme(R.style.MyMaterialTheme);

--- a/app/src/main/java/eu/basicairdata/graziano/gpslogger/utils/AppUtils.java
+++ b/app/src/main/java/eu/basicairdata/graziano/gpslogger/utils/AppUtils.java
@@ -1,0 +1,33 @@
+package eu.basicairdata.graziano.gpslogger.utils;
+
+import android.app.Application;
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.text.TextUtils;
+import android.view.View;
+import android.view.Window;
+
+import androidx.preference.PreferenceManager;
+
+public class AppUtils {
+
+    /**
+     * Updates the navigation bar color based on the provided color theme preference.
+     * If prefColorTheme is "1" , only then the navigation bar color is updated to white color.
+     *
+     * @param window The Window object of the current activity or dialog where the navigation bar color will be updated.
+     * @param applicationContext The application context, used to access shared preferences.
+     */
+    public static void updateNavigationBarColor(Window window, Context applicationContext) {
+        if (window != null && applicationContext instanceof Application) {
+            // Retrieve the preferred color theme from shared preferences and check if it's "1"
+            if (TextUtils.equals("1", PreferenceManager.getDefaultSharedPreferences(applicationContext).getString("prefColorTheme", "2"))) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    window.setNavigationBarColor(Color.WHITE);
+                    window.getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am changing the navigation bar background color to white and the icon color to black only in the case of the light theme. In the dark theme, the navigation bar background is black by default, and the icons are light. Let me know if any further changes are required.

## Light Theme :

![Screenshot_20241002_120521](https://github.com/user-attachments/assets/051b7701-67e8-43e6-8980-536e92d8d8c7)
![Screenshot_20241002_120535](https://github.com/user-attachments/assets/dd8036ac-84f9-452b-be41-4ce411fd0411)

## Dark Theme :

![Screenshot_20241002_120614](https://github.com/user-attachments/assets/44d9dd73-7615-4d9a-ae20-3f3ef86a4827)
![Screenshot_20241002_120916](https://github.com/user-attachments/assets/1c923429-7f11-4c67-94ba-4ae9019ca9e8)
